### PR TITLE
fix: return 409 when pushing duplicate version without overwrite param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 bundler_args: --without development
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.3.0

--- a/lib/geminabox/gem_store.rb
+++ b/lib/geminabox/gem_store.rb
@@ -37,7 +37,7 @@ module Geminabox
         if existing_file_digest != gem.hexdigest
           raise GemStoreError.new(409, "Updating an existing gem is not permitted.\nYou should either delete the existing version, or change your version number.")
         else
-          raise GemStoreError.new(200, "Ignoring upload, you uploaded the same thing previously.\nPlease use -o to ovewrite.")
+          raise GemStoreError.new(409, "Ignoring upload, you uploaded the same thing previously.\nPlease use -o to ovewrite.")
         end
       end
     end

--- a/test/units/geminabox/gem_store_test.rb
+++ b/test/units/geminabox/gem_store_test.rb
@@ -40,6 +40,18 @@ module Geminabox
       end
     end
 
+    def test_ensure_gem_unique
+      file = File.open(GemFactory.gem_file(:example, :platform => "x86_64-linux"))
+      gem = Geminabox::IncomingGem.new(file)
+
+      gem_file = GemStore.new gem
+      gem_file.save
+
+      assert_gem_store_error('409', 'you uploaded the same thing previously') do
+        gem_file.save
+      end
+    end
+
     private
     def assert_gem_store_error(code, message, &block)
       assert_raises GemStoreError do

--- a/test/units/geminabox/http_adapter/template_faraday_adapter_test.rb
+++ b/test/units/geminabox/http_adapter/template_faraday_adapter_test.rb
@@ -34,8 +34,8 @@ module Geminabox
     end
 
     def test_set_auth
-      stub_request(:get, "http://foo:bar@example.com/").
-         to_return(:status => 200, :body => @default, :headers => {})
+      stub_request(:get, "http://example.com/").
+        to_return(:status => 200, :body => @default, :headers => {'Authorization' => Base64.encode64("foo:bar").strip})
 
       connection = @http_adapter.set_auth('http://example.com', 'foo', 'bar')
       response = connection.get('http://example.com')

--- a/test/units/geminabox/proxy/splicer_test.rb
+++ b/test/units/geminabox/proxy/splicer_test.rb
@@ -47,17 +47,8 @@ module Geminabox
       end
 
       def test_local_file_path
-        expected = File.expand_path(file_name, Geminabox::Server.data)
-        assert_equal expected, splice.local_path
-      end
-
-      def test_local_file_path
         expected = File.expand_path(file_name, File.join(Geminabox::Server.data, 'proxy'))
         assert_equal expected, splice.splice_path
-      end
-
-      def test_local_file_exists_without_file
-        assert_equal false, splice.local_file_exists?
       end
 
       def test_splice_file_exists_without_file


### PR DESCRIPTION
Rubygems does not display errors when the response code is successful.  Previously you would only see the error message if you were doing a verbose push.  Without showing the raw HTTP logs a false positive is produced.

By changing the status code to 409 the error will be displayed to the actor.  This is not a functional change server-side.